### PR TITLE
ContinueLeave loop and fixes

### DIFF
--- a/game_loop.py
+++ b/game_loop.py
@@ -39,9 +39,12 @@ class Bouncer():
         self.dm.game_board.add_marker(self.dm.player.position, marker)
 
     def check_action(self, action):
+        if self.dm.room_status[self.dm.get_pos()]['exit'] and action != 'end':
+            ContinueLeave(self.dm, self.username).cmdloop()
+            return
         if action == 'move':
             if self.dm.room_status[self.dm.get_pos()]['escape']:
-                self.place_marker('E')
+                self.place_marker('R')  # Might be redundant
             MoveLoop(self.dm, self.username).cmdloop(self.room_text)
         elif action == 'combat':
             if self.spawn_checker():
@@ -58,6 +61,32 @@ class Bouncer():
             if self.dm.room_status[
                     self.dm.get_pos()]['enemies']:
                 return True
+
+
+class ContinueLeave(cmd.Cmd):
+    intro = 'You found the exit!\nWould you like to leave or continue the run?'
+    prompt = '-> '
+
+    def __init__(self, dm, username):
+        super().__init__()
+        self.dm = dm
+        self.username = username
+        self.leave = False
+
+    def do_continue(self, arg):
+        'Continue the run'
+        return True
+
+    def do_leave(self, arg):
+        'Exit the dungeon with your gold'
+        self.leave = True
+        return True
+
+    def postloop(self):
+        if self.leave:
+            Bouncer(self.dm, self.username, 'end')
+        else:
+            Bouncer(self.dm, self.username, 'move')
 
 
 class MoveLoop(cmd.Cmd):

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -37,14 +37,16 @@ class Leaderboard:
 
     def print_top_x(self, x):
         scores = self.get_scores()
-        if len(scores) > x:
+        if x > len(scores):
             x = len(scores)
         elif len(scores) == 0:
             print('There are no highscores yet')
-        else:
-            for i in range(x):
-                row = ', '.join(scores[i])
-                print(f'{i + 1} {row}')
+            return
+
+        for i in range(x):
+            score = [scores[i][0], str(scores[i][1])]
+            row = ', '.join(score)
+            print(f'{i + 1} {row}')
 
     def idx_one(self, item):
         return item[1]

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -10,11 +10,11 @@ class Leaderboard:
             with open('score.csv', 'r'):
                 pass
         except FileNotFoundError:
-            with open('score.csv', 'w') as f:
+            with open('score.csv', 'w', newline=None) as f:
                 csv.writer(f).writerow(('Username', 'Score'))
 
     def add_score(self, username, gold):
-        with open('score.csv', 'a') as f:
+        with open('score.csv', 'a', newline=None) as f:
             csv.writer(f).writerow((username, gold))
         self.show_rank((username, gold))
 

--- a/menue.py
+++ b/menue.py
@@ -60,10 +60,11 @@ class Menue_loop(cmd.Cmd):
         return True  # Exits the loop
 
     def postloop(self):
-        self.data_handler.update(tuple(self.character))
-        self.data_handler.file_handler.save(
-            self.data_handler.character_data
-        )
+        if self.character:
+            self.data_handler.update(tuple(self.character))
+            self.data_handler.file_handler.save(
+                self.data_handler.character_data
+            )
 
 
 class PickBoardSize(cmd.Cmd):


### PR DESCRIPTION
ContinueLeave loop now exists, and is called when player enters exit-room
- Fix in leaderboard.py, added newline=None to avoid lots of blank lines in csv
- Fix in menue to avoid errors on quitting the game after booting menu without loading a char
- Fix in leaderboard.py, print_top_x so that it does not try to loop through nonexisting indexes if there are too few scores